### PR TITLE
SS-7547: rotate textbox according to boundary rectangle

### DIFF
--- a/PdfPlus/Classes/Shape.cs
+++ b/PdfPlus/Classes/Shape.cs
@@ -941,8 +941,19 @@ namespace PdfPlus
 
             Pl.XTextFormatter textFormatter = new Pl.XTextFormatter(graph);
             textFormatter.Alignment = this.Font.Justification.ToPdf();
-            textFormatter.LayoutRectangle = this.boundary.ToPdf();
-            textFormatter.DrawString(this.Text, pdfFont, font.Color.ToPdfBrush(), this.boundary.ToPdf(), Pd.XStringFormats.TopLeft);
+
+            Rg.Point2d center = new Rg.Point2d(this.boundary.Center.X, this.boundary.Center.Y);
+            Rg.Point2d bottomLeft = center - 0.5 * new Rg.Vector2d(this.boundary.Width, this.boundary.Height);
+            Pd.XRect layoutRect = new Pd.XRect(new Pd.XPoint(bottomLeft.X, bottomLeft.Y), new Pd.XSize(this.boundary.Width, this.boundary.Height));
+
+            textFormatter.LayoutRectangle = layoutRect;
+
+            double angleRad = Rg.Vector3d.VectorAngle(Rg.Vector3d.XAxis, this.boundary.Plane.XAxis, Rg.Plane.WorldXY);
+            double angleDeg = Rhino.RhinoMath.ToDegrees(angleRad);
+            Pd.XGraphicsState state = graph.Save();
+            graph.RotateAtTransform(angleDeg, new Pd.XPoint(center.X, center.Y));
+            textFormatter.DrawString(this.Text, pdfFont, font.Color.ToPdfBrush(), layoutRect, Pd.XStringFormats.TopLeft);
+            graph.Restore(state);
 
             return graph;
         }

--- a/PdfPlus/Utilities/PdfExtensions.cs
+++ b/PdfPlus/Utilities/PdfExtensions.cs
@@ -112,7 +112,7 @@ namespace PdfPlus
         public static Rd.Text3d ToMultiLineTextBlock(this Shape input, double factor = 1.0)
         {
             Rg.Point3d[] c = input.PreviewPolyline.ToArray();
-            Rg.Plane plane = Rg.Plane.WorldXY;
+            Rg.Plane plane = input.Boundary.Plane;
             plane.Origin = c[3] + new Rg.Vector3d(0, -input.Font.Size/5, 0) ;
             List<string> lines = input.BreakLines(input.Text, input.Boundary.Width + 18);
             List<string> subLines = new List<string>();


### PR DESCRIPTION
The text box component now considers the orientation of the rectangle provided when displaying the text.
Example output is shown below.


![PdfPlus_Fix](https://github.com/interopxyz/PdfPlus/assets/43419779/62bd12b4-75c9-4e93-9061-3ebadb61f877)
